### PR TITLE
feat: JWT認証を実装

### DIFF
--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -1,14 +1,14 @@
 module Api
   module V2
     class SessionsController < ApplicationController
-      skip_before_action :require_authentication, only: [:create, :destroy]
+      skip_before_action :require_authentication, only: [ :create, :destroy ]
       rate_limit to: 10, within: 3.minutes, only: :create, with: -> { render json: { error: "Try again later." }, status: :too_many_requests }
 
       def create
         if user = User.authenticate_by(params.permit(:email_address, :password))
           token = JwtService.generate_token_for(user)
-          render json: { 
-            message: "ログインしました", 
+          render json: {
+            message: "ログインしました",
             user: user,
             token: token,
             token_type: "Bearer"

--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -1,20 +1,25 @@
 module Api
   module V2
     class SessionsController < ApplicationController
-      allow_unauthenticated_access only: :create
+      skip_before_action :require_authentication, only: [:create]
       rate_limit to: 10, within: 3.minutes, only: :create, with: -> { render json: { error: "Try again later." }, status: :too_many_requests }
 
       def create
         if user = User.authenticate_by(params.permit(:email_address, :password))
-          start_new_session_for user
-          render json: { message: "ログインしました", user: user }, status: :ok
+          token = JwtService.generate_token_for(user)
+          render json: { 
+            message: "ログインしました", 
+            user: user,
+            token: token,
+            token_type: "Bearer"
+          }, status: :ok
         else
           render json: { error: "メールアドレスまたはパスワードが正しくありません" }, status: :unauthorized
         end
       end
 
       def destroy
-        terminate_session
+        # JWTはステートレスなので、クライアント側でトークンを削除する必要がある
         render json: { message: "ログアウトしました" }, status: :ok
       end
     end

--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V2
     class SessionsController < ApplicationController
-      skip_before_action :require_authentication, only: [:create]
+      skip_before_action :require_authentication, only: [:create, :destroy]
       rate_limit to: 10, within: 3.minutes, only: :create, with: -> { render json: { error: "Try again later." }, status: :too_many_requests }
 
       def create

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -12,35 +12,31 @@ module Authentication
   end
 
   private
-    def authenticated?
-      resume_session
-    end
 
-    def require_authentication
-      resume_session || request_authentication
-    end
+  def require_authentication
+    render json: { error: "認証が必要です" }, status: :unauthorized unless authenticated_user
+  end
 
-    def resume_session
-      Current.session ||= find_session_by_cookie
-    end
+  def authenticated_user
+    @authenticated_user ||= authenticate_user_from_token
+  end
 
-    def find_session_by_cookie
-      Session.find_by(id: cookies.signed[:session_id]) if cookies.signed[:session_id]
-    end
+  def authenticate_user_from_token
+    header = request.headers['Authorization']
+    return nil unless header&.starts_with?('Bearer ')
 
-    def request_authentication
-      render json: { error: "認証が必要です" }, status: :unauthorized
-    end
+    token = header.split(' ').last
+    payload = JwtService.decode(token)
+    return nil unless payload
 
-    def start_new_session_for(user)
-      user.sessions.create!(user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session|
-        Current.session = session
-        cookies.signed.permanent[:session_id] = { value: session.id, httponly: true, same_site: :lax }
-      end
-    end
+    User.find_by(id: payload['user_id'])
+  end
 
-    def terminate_session
-      Current.session.destroy
-      cookies.delete(:session_id)
-    end
+  def Current.user
+    @current_user ||= authenticated_user
+  end
+
+  def request_authentication
+    render json: { error: "認証が必要です" }, status: :unauthorized
+  end
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -22,14 +22,14 @@ module Authentication
   end
 
   def authenticate_user_from_token
-    header = request.headers['Authorization']
-    return nil unless header&.starts_with?('Bearer ')
+    header = request.headers["Authorization"]
+    return nil unless header&.starts_with?("Bearer ")
 
-    token = header.split(' ').last
+    token = header.split(" ").last
     payload = JwtService.decode(token)
     return nil unless payload
 
-    User.find_by(id: payload['user_id'])
+    User.find_by(id: payload["user_id"])
   end
 
   def Current.user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,9 @@ class User < ApplicationRecord
   def admin?
     admin
   end
+
+  # JWTトークンを生成
+  def generate_jwt_token
+    JwtService.generate_token_for(self)
+  end
 end

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -1,5 +1,5 @@
 class JwtService
-  SECRET_KEY = Rails.application.credentials.secret_key_base || Rails.application.secrets.secret_key_base
+  SECRET_KEY = Rails.application.credentials.secret_key_base
 
   def self.encode(payload, exp = 24.hours.from_now)
     payload[:exp] = exp.to_i
@@ -7,7 +7,7 @@ class JwtService
   end
 
   def self.decode(token)
-    decoded = JWT.decode(token, SECRET_KEY, true, algorithm: 'HS256')
+    decoded = JWT.decode(token, SECRET_KEY, true, algorithm: "HS256")
     decoded[0]
   rescue JWT::ExpiredSignature
     nil

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -1,0 +1,26 @@
+class JwtService
+  SECRET_KEY = Rails.application.credentials.secret_key_base || Rails.application.secrets.secret_key_base
+
+  def self.encode(payload, exp = 24.hours.from_now)
+    payload[:exp] = exp.to_i
+    JWT.encode(payload, SECRET_KEY)
+  end
+
+  def self.decode(token)
+    decoded = JWT.decode(token, SECRET_KEY, true, algorithm: 'HS256')
+    decoded[0]
+  rescue JWT::ExpiredSignature
+    nil
+  rescue JWT::DecodeError
+    nil
+  end
+
+  def self.generate_token_for(user)
+    payload = {
+      user_id: user.id,
+      email: user.email_address,
+      admin: user.admin?
+    }
+    encode(payload)
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -12,7 +12,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource "*",
       headers: :any,
-      methods: [ :get, :post, :put, :patch, :delete, :options, :head ],
-      credentials: true
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ]
   end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -8,7 +8,8 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_equal "ログインしました", JSON.parse(response.body)["message"]
-    assert cookies[:session_id]
+    assert JSON.parse(response.body)["token"]
+    assert_equal "Bearer", JSON.parse(response.body)["token_type"]
   end
 
   test "create with invalid credentials" do
@@ -16,13 +17,13 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :unauthorized
     assert_equal "メールアドレスまたはパスワードが正しくありません", JSON.parse(response.body)["error"]
-    assert_nil cookies[:session_id]
+    response_json = JSON.parse(response.body)
+    refute response_json["token"]
   end
 
   test "destroy" do
-    sign_in_as(@user)
-
-    delete api_v2_session_path, as: :json
+    token = JwtService.generate_token_for(@user)
+    delete api_v2_session_path, headers: { "Authorization" => "Bearer #{token}" }, as: :json
 
     assert_response :ok
     assert_equal "ログアウトしました", JSON.parse(response.body)["message"]

--- a/test/test_helpers/session_test_helper.rb
+++ b/test/test_helpers/session_test_helper.rb
@@ -1,16 +1,12 @@
 module SessionTestHelper
   def sign_in_as(user)
-    Current.session = user.sessions.create!
-
-    ActionDispatch::TestRequest.create.cookie_jar.tap do |cookie_jar|
-      cookie_jar.signed[:session_id] = Current.session.id
-      cookies["session_id"] = cookie_jar[:session_id]
-    end
+    token = JwtService.generate_token_for(user)
+    @request.headers["Authorization"] = "Bearer #{token}" if @request
   end
 
   def sign_out
-    Current.session&.destroy!
-    cookies.delete("session_id")
+    # JWTはステートレスなので、クライアント側でトークンを削除する必要がある
+    # テストでは特に何もしない
   end
 end
 


### PR DESCRIPTION
- JwtServiceを追加してトークン生成・検証機能を実装
- SessionsControllerをJWT認証に変更しトークンを返すように修正
- Authentication concernをJWTトークン検証に更新
- UserモデルにJWTトークン生成メソッドを追加
- CORS設定をJWT認証用に修正（credentials: trueを削除）
- CurrentモデルをJWT認証用にシンプル化