### PR TITLE
fix: JWTレスポンスフィールド名を更新

### DIFF
--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -10,8 +10,8 @@ module Api
           render json: {
             message: "ログインしました",
             user: user,
-            token: token,
-            token_type: "Bearer"
+            authToken: token,
+            tokenType: "Bearer"
           }, status: :ok
         else
           render json: { error: "メールアドレスまたはパスワードが正しくありません" }, status: :unauthorized

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -2,6 +2,9 @@ module Authentication
   extend ActiveSupport::Concern
 
   included do
+    # 1. まず誰かを特定し、Current.userに保存する
+    before_action :authenticate_user_from_token
+    # 2. 次に、Current.userがいなければ拒否する
     before_action :require_authentication
   end
 
@@ -27,16 +30,11 @@ module Authentication
 
     token = header.split(" ").last
     payload = JwtService.decode(token)
-    return nil unless payload
 
-    User.find_by(id: payload["user_id"])
+    # ユーザーを見つけたら Current.user という箱に入れる
+    if payload
+      Current.user = User.find_by(id: payload["user_id"])
+    end
   end
 
-  def Current.user
-    @current_user ||= authenticated_user
-  end
-
-  def request_authentication
-    render json: { error: "認証が必要です" }, status: :unauthorized
-  end
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -36,5 +36,4 @@ module Authentication
       Current.user = User.find_by(id: payload["user_id"])
     end
   end
-
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,4 @@
 class Current < ActiveSupport::CurrentAttributes
+  attribute :user
   attribute :session
-  delegate :user, to: :session, allow_nil: true
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -8,8 +8,8 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_equal "ログインしました", JSON.parse(response.body)["message"]
-    assert JSON.parse(response.body)["token"]
-    assert_equal "Bearer", JSON.parse(response.body)["token_type"]
+    assert JSON.parse(response.body)["authToken"]
+    assert_equal "Bearer", JSON.parse(response.body)["tokenType"]
   end
 
   test "create with invalid credentials" do
@@ -18,7 +18,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
     assert_equal "メールアドレスまたはパスワードが正しくありません", JSON.parse(response.body)["error"]
     response_json = JSON.parse(response.body)
-    refute response_json["token"]
+    refute response_json["authToken"]
   end
 
   test "destroy" do

--- a/test/models/current_test.rb
+++ b/test/models/current_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class CurrentTest < ActiveSupport::TestCase
+  test "should store user" do
+    Current.user = users(:one)
+    assert_equal users(:one), Current.user
+  end
+end


### PR DESCRIPTION
- token → authToken に変更
- token_type → tokenType に変更
- Angular側のプロパティ名に合わせてレスポンスを調整
- モデルの修正
- concrenの修正