### PR TITLE
feat: FavoriteItem APIを実装

### DIFF
--- a/app/controllers/api/v2/favorite_items_controller.rb
+++ b/app/controllers/api/v2/favorite_items_controller.rb
@@ -1,6 +1,6 @@
 class Api::V2::FavoriteItemsController < ApplicationController
   before_action :require_authentication
-  before_action :set_favorite_item, only: [:show, :update, :destroy]
+  before_action :set_favorite_item, only: [ :show, :update, :destroy ]
 
   # GET /api/v2/favorite_items
   def index

--- a/app/controllers/api/v2/favorite_items_controller.rb
+++ b/app/controllers/api/v2/favorite_items_controller.rb
@@ -1,0 +1,58 @@
+class Api::V2::FavoriteItemsController < ApplicationController
+  before_action :require_authentication
+  before_action :set_favorite_item, only: [:show, :update, :destroy]
+
+  # GET /api/v2/favorite_items
+  def index
+    @favorite_items = Current.user.favorite_items.order(created_at: :desc)
+    render json: @favorite_items
+  end
+
+  # GET /api/v2/favorite_items/:id
+  def show
+    render json: @favorite_item
+  end
+
+  # POST /api/v2/favorite_items
+  def create
+    @favorite_item = Current.user.favorite_items.new(favorite_item_params)
+
+    if @favorite_item.save
+      render json: @favorite_item, status: :created
+    else
+      render json: { errors: @favorite_item.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PUT /api/v2/favorite_items/:id
+  def update
+    if @favorite_item.update(favorite_item_params)
+      render json: @favorite_item
+    else
+      render json: { errors: @favorite_item.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /api/v2/favorite_items/:id
+  def destroy
+    @favorite_item.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_favorite_item
+    @favorite_item = Current.user.favorite_items.find(params.expect(:id))
+  end
+
+  def favorite_item_params
+    params.expect(favorite_item: [
+      :item_name,
+      :brand_name,
+      :category,
+      :price,
+      :memo,
+      :url
+    ])
+  end
+end

--- a/app/models/favorite_item.rb
+++ b/app/models/favorite_item.rb
@@ -9,5 +9,5 @@ class FavoriteItem < ApplicationRecord
   validates :price, numericality: { only_integer: true, allow_blank: true }
 
   # URLのフォーマット検証
-  validates :url, format: { with: URI::regexp(%w[http https]), allow_blank: true }
+  validates :url, format: { with: URI.regexp(%w[http https]), allow_blank: true }
 end

--- a/app/models/favorite_item.rb
+++ b/app/models/favorite_item.rb
@@ -1,0 +1,13 @@
+class FavoriteItem < ApplicationRecord
+  belongs_to :user
+
+  validates :item_name, presence: true
+  validates :brand_name, presence: true
+  validates :category, presence: true
+
+  # 価格は整数のみ許可
+  validates :price, numericality: { only_integer: true, allow_blank: true }
+
+  # URLのフォーマット検証
+  validates :url, format: { with: URI::regexp(%w[http https]), allow_blank: true }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
   has_many :brands, dependent: :destroy
+  has_many :favorite_items, dependent: :destroy
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
       resources :passwords, param: :token, only: [ :create, :update ]
       # ブランド管理
       resources :brands
+      # お気に入りアイテム管理
+      resources :favorite_items
       # アイテム一覧・詳細
       resources :items, only: [ :index, :show ]
     end

--- a/db/migrate/20260131164506_create_favorite_items.rb
+++ b/db/migrate/20260131164506_create_favorite_items.rb
@@ -1,0 +1,15 @@
+class CreateFavoriteItems < ActiveRecord::Migration[8.1]
+  def change
+    create_table :favorite_items do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :item_name
+      t.string :brand_name
+      t.string :category
+      t.integer :price
+      t.text :memo
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_29_180526) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_31_164506) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -22,6 +22,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_29_180526) do
     t.string "url"
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_brands_on_user_id"
+  end
+
+  create_table "favorite_items", force: :cascade do |t|
+    t.string "brand_name"
+    t.string "category"
+    t.datetime "created_at", null: false
+    t.string "item_name"
+    t.text "memo"
+    t.integer "price"
+    t.datetime "updated_at", null: false
+    t.string "url"
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_favorite_items_on_user_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -44,5 +57,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_29_180526) do
   end
 
   add_foreign_key "brands", "users"
+  add_foreign_key "favorite_items", "users"
   add_foreign_key "sessions", "users"
 end

--- a/test/controllers/api/v2/favorite_items_controller_test.rb
+++ b/test/controllers/api/v2/favorite_items_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V2::FavoriteItemsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/favorite_items.yml
+++ b/test/fixtures/favorite_items.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  item_name: MyString
+  brand_name: MyString
+  category: MyString
+  price: 1
+  memo: MyText
+  url: MyString
+
+two:
+  user: two
+  item_name: MyString
+  brand_name: MyString
+  category: MyString
+  price: 1
+  memo: MyText
+  url: MyString

--- a/test/models/favorite_item_test.rb
+++ b/test/models/favorite_item_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoriteItemTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- FavoriteItemsControllerでCRUD操作を実装
- FavoriteItemモデルにバリデーションを追加
- Userモデルにfavorite_items関連付けを追加
- ルーティングにfavorite_itemsを追加
- マイグレーションを実行してfavorite_itemsテーブルを作成
- AngularのFavoriteItemServiceと連携可能
- JWT認証でユーザーごとのアイテム管理を実現